### PR TITLE
fixed image3.png and image4.png position

### DIFF
--- a/Newsletters/Yearn Finance Newsletter #41/Yearn Finance Newsletter #41.md
+++ b/Newsletters/Yearn Finance Newsletter #41/Yearn Finance Newsletter #41.md
@@ -23,7 +23,7 @@ Thanks to [loldefi](https://twitter.com/loldefi), apparel celebrating YFI’s fi
 
 ## Yearn’s Market Share In Aggregator Market Rises
 
-![alt_text](image3.png "image_tooltip")
+![alt_text](image4.png "image_tooltip")
 
 In Q2 2021, Yearn’s market share in the yield aggregator market rose from 29% to 69%. We saw an impressive 136% growth in our AUM, as it reached over five billion dollars. We are working constantly to find you the best risk-adjusted returns in the market. Deposit capital to our yVaults and let the Strategists do all the hard work for you.
 
@@ -31,7 +31,7 @@ View more details about Yearn and general DeFi analytics in this Messari [report
 
 ## Yearn To Be Added To Compound
 
-![alt_text](image4.png "image_tooltip")
+![alt_text](image3.png "image_tooltip")
 
 A proposal has been created and contracts have been deployed to add YFI as a market to Compound Finance. Each token will have a zero collateral factor (initially), the same interest rate model (as COMP/LINK), and a reserve factor of 25% for each market (which is standard).
 


### PR DESCRIPTION
"Yearn’s Market Share In Aggregator Market Rises" and "Yearn To Be Added To Compound" ref image placements were mixed up (probably due to the automatic fetching tool)