### PR TITLE
fix(layouts): bad uri

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,7 +60,7 @@ gtag('config', '{{site.ganalytics}}');
               </button>
               <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="https://yearn-comms.vercel.app/#">English</a></li>
-                <li><a class="dropdown-item" href="https://chinese-yearn-comms.vercel.app/##">汉语</a></li>
+                <li><a class="dropdown-item" href="https://chinese-yearn-comms.vercel.app/#">汉语</a></li>
                 <li><a class="dropdown-item" href="https://french-yearn-comms.vercel.app/#">Français</a></li>
                 <li><a class="dropdown-item" href="https://german-yearn-comms.vercel.app/#">Deutsch</a></li>
                 <li><a class="dropdown-item" href="https://hindi-yearn-comms.vercel.app/#">हिन्दी</a></li>


### PR DESCRIPTION
Fix for a build error caused by bad formatting of the language dropdown URLs:

```
ruby/2.7.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): "https://chinese-yearn-comms.vercel.app/##" (URI::InvalidURIError)
```