### PR TITLE
[CMT-553-861] Resolve article bug on french page

### DIFF
--- a/Tweets/_posts/Claim from old ygov/2021-07-10-Claim-from-old-ygov.md
+++ b/Tweets/_posts/Claim from old ygov/2021-07-10-Claim-from-old-ygov.md
@@ -4,7 +4,7 @@ title:  "Réclamer vos récompenses provenant vieux yGov"
 categories: [ Tweets ]
 image: ./Claim-from-old-ygov/amount-in-old-ygov.jpg
 author: Dudesahn
-translator:Cryptouf
+translator: Cryptouf
 publish: true
 ---
 


### PR DESCRIPTION
## Description

To resolve the issue I fixed a spacing error in the "Claim from old jgov" Twitter post between the field "translator" and the translator's name. This bug was fixed because it resulted in a partial card of the post showing up on the french yearn blog home page, which is not the expected behaviour.

## Fixed issue

Fixes #842\
Resolves #842

## Type of change

* [X] Fix a Typo

## Resources

Visual of fix\
<img width="590" alt="Screen Shot 2022-01-14 at 6 08 10 PM" src="[https://user-images.githubusercontent.com/97762526/149596685-d73d61d5-c4e2-4e45-9054-9fc76cbf5474.png](https://user-images.githubusercontent.com/97762526/149596685-d73d61d5-c4e2-4e45-9054-9fc76cbf5474.png)">