### PR TITLE
[CMT-757-1102] fix: typo in "how-yearn-calculates-estimated-returns" article

### DIFF
--- a/public/_posts/_articles/marco-worms/how-yearn-calculates-estimated-returns/en.md
+++ b/public/_posts/_articles/marco-worms/how-yearn-calculates-estimated-returns/en.md
@@ -68,7 +68,7 @@ So we had a really conservative APY calculation before the mentioned episode abo
 * **Boost:** Boost how much of the multiplier you get from staked veCRV
 * **Convex APR:** Current convex apr if you deposit to convex
 * **Gross APR:** Vault total APR before deducted fees
-* **Net APY: **Vault current APY
+* **Net APY:** Vault current APY
 
 
 


### PR DESCRIPTION
## Description

This pull request is about fixing line 71 typo on original file

* [X] Fix a Typo