### PR TITLE
feat: Add id to headers (h1–h6) for deep-linking support

### DIFF
--- a/components/TemplateArticle.js
+++ b/components/TemplateArticle.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import	React					from	'react';
 import	Link					from	'next/link';
 import	{useRouter}				from	'next/router';
@@ -10,7 +11,8 @@ import	rehypeRaw				from	'rehype-raw';
 import	useLocalization			from	'contexts/useLocalization';
 import	IconChevron				from	'components/icons/IconChevron';
 import	{parseMarkdown}			from	'utils';
-import axios from 'axios';
+import 	axios 					from 'axios';
+import 	urlSlug 				from 'url-slug';
 
 function	LinkPreview(props) {
 	const	[metadata, set_metadata] = React.useState({});
@@ -37,6 +39,14 @@ function	LinkPreview(props) {
 			</slot>
 		</a>
 	);
+}
+
+function	getHeaderSlug(props) {
+	const content = props?.children?.[0];
+	if (typeof content === 'string') {
+		return urlSlug(content);
+	}
+	return;
 }
 
 function	Template({routerPath, path, post, newer, older}) {
@@ -96,12 +106,12 @@ function	Template({routerPath, path, post, newer, older}) {
 						remarkPlugins={[remarkGfm]}
 						components={{
 							a: ({...props}) => <a {...props} target={'_blank'} rel={'noopener noreferrer'} className={'text-yearn-blue dark:text-white hover:underline'} />,
-							h1: ({...props}) => <h1 {...props} className={'text-dark-blue-1 dark:text-white'} />,
-							h2: ({...props}) => <h2 {...props} className={'text-dark-blue-1 dark:text-white'} />,
-							h3: ({...props}) => <h3 {...props} className={'text-dark-blue-1 dark:text-white'} />,
-							h4: ({...props}) => <h4 {...props} className={'text-dark-blue-1 dark:text-white'} />,
-							h5: ({...props}) => <h5 {...props} className={'text-dark-blue-1 dark:text-white'} />,
-							h6: ({...props}) => <h6 {...props} className={'text-dark-blue-1 dark:text-white'} />,
+							h1: ({node, ...props}) => <h1 {...props} id={getHeaderSlug(props)} className={'text-dark-blue-1 dark:text-white'} />,
+							h2: ({node, ...props}) => <h2 {...props} id={getHeaderSlug(props)} className={'text-dark-blue-1 dark:text-white'} />,
+							h3: ({node, ...props}) => <h3 {...props} id={getHeaderSlug(props)} className={'text-dark-blue-1 dark:text-white'} />,
+							h4: ({node, ...props}) => <h4 {...props} id={getHeaderSlug(props)} className={'text-dark-blue-1 dark:text-white'} />,
+							h5: ({node, ...props}) => <h5 {...props} id={getHeaderSlug(props)} className={'text-dark-blue-1 dark:text-white'} />,
+							h6: ({node, ...props}) => <h6 {...props} id={getHeaderSlug(props)} className={'text-dark-blue-1 dark:text-white'} />,
 							b: ({...props}) => <b {...props} className={'text-dark-blue-1 dark:text-white'} />,
 							iframe: ({...props}) => <iframe {...props} className={'aspect-video w-full h-full'} />,
 							strong: ({...props}) => <strong {...props} className={'text-dark-blue-1 dark:text-white'} />,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "remark-html": "15.0.1",
     "sharp": "^0.29.3",
     "tailwindcss": "^3.0.16",
-    "url-metadata": "^2.5.0"
+    "url-metadata": "^2.5.0",
+    "url-slug": "^3.0.4"
   },
   "devDependencies": {
     "eslint": "^8.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5786,6 +5786,11 @@ url-metadata@^2.5.0:
     standard "^12.0.1"
     underscore "^1.8.3"
 
+url-slug@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/url-slug/-/url-slug-3.0.4.tgz#3278b556666389cd88d9210a12e7577dafac6d57"
+  integrity sha512-C880WJTo68O4J59i+w9Yp4P0iDUrMeCAVwNvHAYjSc59XsO4pkPfe8bsEHEyZrEfWWy8BDyxMQi6BPVHp/GEbg==
+
 use-subscription@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"


### PR DESCRIPTION
## Description

When applied this pull request will add an `id` prop to headers (h1–h6) for deep-linking support

## Fixed issue

Fixes https://github.com/yearn/yearn-comms/issues/1510

## Type of change

- [X] Feature

## Resources

<img width="1140" alt="Measuring_risk_for_DeFi_yield_strategies" src="https://user-images.githubusercontent.com/78794805/202189404-e79f1f5c-faf2-4739-a08f-e663164ba4d4.png">
