### PR TITLE
fix: Add missing forward slash

### DIFF
--- a/components/TemplateArticle.js
+++ b/components/TemplateArticle.js
@@ -57,7 +57,7 @@ function	Template({routerPath, path, post, newer, older}) {
 		<div className={'-mt-2 md:-mt-12'}>
 			<Head>
 				<title>{post?.title || ''}</title>
-				{post?.image?.url ? <meta property={'og:image'} content={post.image.url} /> : null}
+				{post?.image?.src ? <meta property={'og:image'} content={post.image.src} /> : null}
 			</Head>
 			<NextSeo
 				title={post?.title || ''}

--- a/utils/content.js
+++ b/utils/content.js
@@ -68,7 +68,7 @@ export function getPostBySlug(dir, slug, fields = [], locale, withFallback) {
 					const {src, width, height} = data[field];
 					if ((src || '').startsWith('./')) {
 						items[field] = {
-							src: src.replace('./', `/_posts/${dir}${slug}/`),
+							src: src.replace('./', `/_posts/${dir}/${slug}/`),
 							width,
 							height
 						};


### PR DESCRIPTION
## Description

* Add the missing forward slash after the the `dir`;
* Changes the prop name from `url` to `src`

## Fixed issue

Fixes https://github.com/yearn/yearn-comms/issues/1519

## Type of change

- [x] Bug fix

## Resources

<img width="1281" alt="Screenshot 2022-11-20 at 15 06 38" src="https://user-images.githubusercontent.com/78794805/202903626-6786a2c3-ae21-45bf-8e5c-e5a013533ba4.png">
